### PR TITLE
Add interactive 7x7 board

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,12 @@
-import logo from './logo.svg';
 import './App.css';
+import Board from './Board';
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+        <h1>7x7 RPG</h1>
+        <Board />
       </header>
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders 7x7 board', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const board = screen.getByTestId('board');
+  expect(board.children).toHaveLength(49);
 });

--- a/src/Board.css
+++ b/src/Board.css
@@ -1,0 +1,41 @@
+.board-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(7, 40px);
+  grid-template-rows: repeat(7, 40px);
+  gap: 2px;
+}
+
+.tile {
+  width: 40px;
+  height: 40px;
+  background-color: #eee;
+  border: 1px solid #ccc;
+}
+
+.tile.hero {
+  background-color: #f44336;
+}
+
+.dpad {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dpad button {
+  width: 40px;
+  height: 40px;
+  margin: 2px;
+}
+
+.dpad .middle-row {
+  display: flex;
+}

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import './Board.css';
+
+const BOARD_SIZE = 7;
+const CENTER = Math.floor(BOARD_SIZE / 2);
+
+function Board() {
+  const [position, setPosition] = useState({ row: CENTER, col: CENTER });
+
+  const move = (dRow, dCol) => {
+    setPosition(pos => {
+      const newRow = Math.min(Math.max(pos.row + dRow, 0), BOARD_SIZE - 1);
+      const newCol = Math.min(Math.max(pos.col + dCol, 0), BOARD_SIZE - 1);
+      return { row: newRow, col: newCol };
+    });
+  };
+
+  const moveUp = () => move(-1, 0);
+  const moveDown = () => move(1, 0);
+  const moveLeft = () => move(0, -1);
+  const moveRight = () => move(0, 1);
+
+  const tiles = [];
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      const isHero = r === position.row && c === position.col;
+      tiles.push(
+        <div
+          key={`${r}-${c}`}
+          className={`tile${isHero ? ' hero' : ''}`}
+          role="presentation"
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="board-container">
+      <div className="board" data-testid="board">
+        {tiles}
+      </div>
+      <div className="dpad">
+        <button onClick={moveUp} aria-label="up">↑</button>
+        <div className="middle-row">
+          <button onClick={moveLeft} aria-label="left">←</button>
+          <button onClick={moveRight} aria-label="right">→</button>
+        </div>
+        <button onClick={moveDown} aria-label="down">↓</button>
+      </div>
+    </div>
+  );
+}
+
+export default Board;


### PR DESCRIPTION
## Summary
- introduce `Board` component rendering a 7x7 grid with a hero token
- implement move functions and mobile friendly D‑pad
- show board in `App`
- add basic test verifying board size

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685feabfd960832b8d19500c68d5bf15