### PR TITLE
Add D-pad visibility toggle

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -39,3 +39,23 @@
 .dpad .middle-row {
   display: flex;
 }
+
+.board-container.collapsed .dpad {
+  display: none;
+}
+
+.dpad-toggle {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .dpad-toggle {
+    display: block;
+    margin-top: 10px;
+    background: transparent;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 4px 8px;
+    color: inherit;
+  }
+}

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -6,6 +6,7 @@ const CENTER = Math.floor(BOARD_SIZE / 2);
 
 function Board() {
   const [position, setPosition] = useState({ row: CENTER, col: CENTER });
+  const [showDpad, setShowDpad] = useState(true);
 
   const move = (dRow, dCol) => {
     setPosition(pos => {
@@ -35,18 +36,28 @@ function Board() {
   }
 
   return (
-    <div className="board-container">
+    <div className={`board-container${showDpad ? '' : ' collapsed'}`}>
       <div className="board" data-testid="board">
         {tiles}
       </div>
-      <div className="dpad">
-        <button onClick={moveUp} aria-label="up">↑</button>
-        <div className="middle-row">
-          <button onClick={moveLeft} aria-label="left">←</button>
-          <button onClick={moveRight} aria-label="right">→</button>
+      <button
+        type="button"
+        className="dpad-toggle"
+        onClick={() => setShowDpad(prev => !prev)}
+        aria-label="toggle dpad"
+      >
+        {showDpad ? 'Hide D-pad' : 'Show D-pad'}
+      </button>
+      {showDpad && (
+        <div className="dpad">
+          <button onClick={moveUp} aria-label="up">↑</button>
+          <div className="middle-row">
+            <button onClick={moveLeft} aria-label="left">←</button>
+            <button onClick={moveRight} aria-label="right">→</button>
+          </div>
+          <button onClick={moveDown} aria-label="down">↓</button>
         </div>
-        <button onClick={moveDown} aria-label="down">↓</button>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enable collapsible D-pad for mobile users
- add CSS styles for collapsed state

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fed1353fc832b8ebc08423355945d