### PR TITLE
Add keyboard controls

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -7,16 +7,23 @@ test('renders 7x7 board', () => {
   expect(board.children).toHaveLength(49);
 });
 
-test('hero stays centered after arrow key press', () => {
+test('arrow key moves world position while hero stays centered', () => {
   render(<App />);
   const board = screen.getByTestId('board');
   const centerIndex = Math.floor(board.children.length / 2);
   const centerTile = board.children[centerIndex];
   expect(centerTile).toHaveClass('hero');
+  const startRow = Number(centerTile.getAttribute('data-row'));
+  const startCol = Number(centerTile.getAttribute('data-col'));
 
   fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
 
-  const centerTileAfter = board.children[centerIndex];
+  const boardAfter = screen.getByTestId('board');
+  const centerTileAfter = boardAfter.children[centerIndex];
   expect(centerTileAfter).toHaveClass('hero');
-  expect(board.querySelectorAll('.hero')).toHaveLength(1);
+  expect(boardAfter.querySelectorAll('.hero')).toHaveLength(1);
+  const endRow = Number(centerTileAfter.getAttribute('data-row'));
+  const endCol = Number(centerTileAfter.getAttribute('data-col'));
+  expect(endRow).toBe(startRow);
+  expect(endCol).toBe(startCol + 1);
 });

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './Board.css';
 
 const BOARD_SIZE = 7;
@@ -23,6 +23,32 @@ function Board() {
   const moveLeft = () => move(0, -1);
   const moveRight = () => move(0, 1);
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      switch (e.key) {
+        case 'ArrowUp':
+          moveUp();
+          break;
+        case 'ArrowDown':
+          moveDown();
+          break;
+        case 'ArrowLeft':
+          moveLeft();
+          break;
+        case 'ArrowRight':
+          moveRight();
+          break;
+        default:
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   const tiles = [];
   for (let r = 0; r < BOARD_SIZE; r++) {
     for (let c = 0; c < BOARD_SIZE; c++) {
@@ -35,6 +61,8 @@ function Board() {
           key={`${worldRow}-${worldCol}`}
           className={`tile${isHero ? ' hero' : ''}`}
           role="presentation"
+          data-row={worldRow}
+          data-col={worldCol}
         />
       );
     }


### PR DESCRIPTION
## Summary
- add keyboard controls with `useEffect`
- expose tile coordinates for tests
- ensure hero stays centered while world position changes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fef30a9bc832ba712386b7e81c5f6