### PR TITLE
Add viewport-specific D-pad toggle test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -20,3 +20,28 @@ test('hero stays centered after arrow key press', () => {
   expect(centerTileAfter).toHaveClass('hero');
   expect(board.querySelectorAll('.hero')).toHaveLength(1);
 });
+
+test('D-pad can be toggled on small screens', () => {
+  window.matchMedia = jest.fn().mockImplementation(query => ({
+    matches: query.includes('(max-width: 600px)'),
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+
+  const { container } = render(<App />);
+
+  const toggle = screen.getByRole('button', { name: /hide d-pad/i });
+  expect(toggle).toBeInTheDocument();
+  expect(container.querySelector('.dpad')).toBeInTheDocument();
+
+  fireEvent.click(toggle);
+  expect(container.querySelector('.dpad')).not.toBeInTheDocument();
+
+  fireEvent.click(toggle);
+  expect(container.querySelector('.dpad')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add matchMedia mock for small viewport test
- verify that the D-pad toggles visibility via the toggle button

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fef342d64832b9c3b9238e780b11a