### PR TITLE
Fix arrow key scroll behavior

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -24,6 +24,7 @@ function Board() {
 
   useEffect(() => {
     const handleKeyDown = (e) => {
+      e.preventDefault();
       switch (e.key) {
         case 'ArrowUp':
           moveUp();


### PR DESCRIPTION
## Summary
- prevent browser scroll on arrow key press

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3418998832ba2b27807557f319a