### PR TITLE
Add D-pad button movement test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -28,6 +28,28 @@ test('arrow key moves world position while hero stays centered', () => {
   expect(endCol).toBe(startCol + 1);
 });
 
+test('clicking D-pad button moves world position while hero stays centered', () => {
+  render(<App />);
+  const board = screen.getByTestId('board');
+  const centerIndex = Math.floor(board.children.length / 2);
+  const centerTile = board.children[centerIndex];
+  expect(centerTile).toHaveClass('hero');
+  const startRow = Number(centerTile.getAttribute('data-row'));
+  const startCol = Number(centerTile.getAttribute('data-col'));
+
+  const rightButton = screen.getByRole('button', { name: /right/i });
+  fireEvent.click(rightButton);
+
+  const boardAfter = screen.getByTestId('board');
+  const centerTileAfter = boardAfter.children[centerIndex];
+  expect(centerTileAfter).toHaveClass('hero');
+  expect(boardAfter.querySelectorAll('.hero')).toHaveLength(1);
+  const endRow = Number(centerTileAfter.getAttribute('data-row'));
+  const endCol = Number(centerTileAfter.getAttribute('data-col'));
+  expect(endRow).toBe(startRow);
+  expect(endCol).toBe(startCol + 1);
+});
+
 test('D-pad can be toggled on small screens', () => {
   window.matchMedia = jest.fn().mockImplementation(query => ({
     matches: query.includes('(max-width: 600px)'),


### PR DESCRIPTION
## Summary
- test D-pad button moves world position to the right while hero stays centered

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3486b00832b97126d717b946075