### PR TITLE
Add map data and render tiles with images

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -16,11 +16,13 @@
   width: 40px;
   height: 40px;
   background-color: #eee;
+  background-size: cover;
+  background-position: center;
   border: 1px solid #ccc;
 }
 
 .tile.hero {
-  background-color: #f44336;
+  box-shadow: inset 0 0 0 2px #f44336;
 }
 
 .dpad {

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import './Board.css';
+import level1 from './maps/level1';
+import floorImg from './assets/environment/visual_grid.png';
+import wallImg from './assets/environment/wall_blocking.png';
+import waterImg from './assets/environment/water0.png';
+
+const tileImages = {
+  floor: floorImg,
+  wall: wallImg,
+  water: waterImg,
+};
 
 const BOARD_SIZE = 7;
 const CENTER = Math.floor(BOARD_SIZE / 2);
@@ -56,6 +66,9 @@ function Board() {
       const worldRow = worldPosition.row + (r - CENTER);
       const worldCol = worldPosition.col + (c - CENTER);
       const isHero = r === CENTER && c === CENTER;
+      const rowData = level1[worldRow];
+      const tileType = rowData && rowData[worldCol] ? rowData[worldCol] : 'floor';
+      const bg = tileImages[tileType] || floorImg;
       tiles.push(
         <div
           key={`${worldRow}-${worldCol}`}
@@ -63,6 +76,7 @@ function Board() {
           role="presentation"
           data-row={worldRow}
           data-col={worldCol}
+          style={{ backgroundImage: `url(${bg})` }}
         />
       );
     }

--- a/src/maps/level1.js
+++ b/src/maps/level1.js
@@ -1,0 +1,14 @@
+const level1 = [
+  ['wall','wall','wall','wall','wall','wall','wall','wall','wall','wall'],
+  ['wall','floor','floor','floor','floor','floor','floor','floor','floor','wall'],
+  ['wall','floor','floor','floor','floor','floor','floor','floor','floor','wall'],
+  ['wall','floor','floor','floor','floor','floor','floor','floor','floor','wall'],
+  ['wall','floor','floor','water','water','water','water','floor','floor','wall'],
+  ['wall','floor','floor','water','floor','floor','water','floor','floor','wall'],
+  ['wall','floor','floor','water','water','water','water','floor','floor','wall'],
+  ['wall','floor','floor','floor','floor','floor','floor','floor','floor','wall'],
+  ['wall','floor','floor','floor','floor','floor','floor','floor','floor','wall'],
+  ['wall','wall','wall','wall','wall','wall','wall','wall','wall','wall'],
+];
+
+export default level1;


### PR DESCRIPTION
## Summary
- add level1 map data
- style tiles with images based on map
- make hero tile show red border instead of fill

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff4c36724832b98846e92df40dc9f