### PR TITLE
Fix tile image mapping

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -9,6 +9,7 @@ import floorImg from './assets/environment/visual_grid.png';
 import wallImg from './assets/environment/wall_blocking.png';
 import waterImg from './assets/environment/water0.png';
 
+const tileImages = {
   floor: floorImg,
   wall: wallImg,
   water: waterImg,


### PR DESCRIPTION
## Summary
- define `tileImages` at the top of `Board.jsx`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7aa9354832bbef3f154dfac7820