### PR TITLE
Fix duplicate board container

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -177,29 +177,9 @@ function Board() {
   }
 
   return (
-    <div className={`board-container${showDpad ? '' : ' collapsed'}`}>
-      <div className="status" data-testid="status">HP: {playerHealth}</div>
-      <div className="board" data-testid="board">
-        {tiles}
-      </div>
-      <button
-        type="button"
-        className="dpad-toggle"
-        onClick={() => setShowDpad(prev => !prev)}
-        aria-label="toggle dpad"
-      >
-        {showDpad ? 'Hide D-pad' : 'Show D-pad'}
-      </button>
-      {showDpad && (
-        <div className="dpad">
-          <button onClick={moveUp} aria-label="up">↑</button>
-          <div className="middle-row">
-            <button onClick={moveLeft} aria-label="left">←</button>
-            <button onClick={moveRight} aria-label="right">→</button>
-          </div>
-          <button onClick={moveDown} aria-label="down">↓</button>
     <div>
       <div className={`board-container${showDpad ? '' : ' collapsed'}`}>
+        <div className="status" data-testid="status">HP: {playerHealth}</div>
         <div className="board" data-testid="board">
           {tiles}
         </div>


### PR DESCRIPTION
## Summary
- cleanup JSX layout so D-pad and inventory appear once

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7af5840832b8e49af36f171d140