### PR TITLE
Update board to use global health/gold

### DIFF
--- a/src/Monster.test.js
+++ b/src/Monster.test.js
@@ -1,9 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import Board from './Board';
+import { GameProvider } from './GameContext';
 
 // 몬스터가 보드에 표시되는지 확인
 test('monster appears on the board', () => {
-  render(<Board />);
+  render(
+    <GameProvider>
+      <Board />
+    </GameProvider>
+  );
   const monsterTiles = screen.getAllByRole('presentation').filter(tile =>
     tile.classList.contains('monster')
   );
@@ -12,11 +17,15 @@ test('monster appears on the board', () => {
 
 // 몬스터 위로 이동하면 체력이 감소한다
 test('colliding with monster decreases player HP', () => {
-  render(<Board />);
+  render(
+    <GameProvider>
+      <Board />
+    </GameProvider>
+  );
   const status = screen.getByTestId('status');
-  expect(status).toHaveTextContent('HP: 10');
+  expect(status).toHaveTextContent('HP: 100');
 
   fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
 
-  expect(status).toHaveTextContent('HP: 9');
+  expect(status).toHaveTextContent('HP: 99');
 });


### PR DESCRIPTION
## Summary
- rely on `GameContext` for health and gold in `Board`
- update monster tests for new health values

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd7c6250832b89ac8196bac03de2