### PR TITLE
Add rounded design to tiles and interface

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -15,10 +15,13 @@
 .tile {
   width: 40px;
   height: 40px;
-  background-color: #eee;
-  background-size: cover;
+  background-color: #f8f8f8;
+  background-size: contain;
+  background-repeat: no-repeat;
   background-position: center;
   border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: inherit;
 }
 
 .tile.hero {
@@ -45,6 +48,10 @@
   width: 40px;
   height: 40px;
   margin: 2px;
+  background-color: #fff;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  font-family: inherit;
 }
 
 .dpad .middle-row {
@@ -57,12 +64,21 @@
 
 .dpad-toggle {
   display: none;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: inherit;
 }
 
 .inventory {
   margin-top: 10px;
   list-style: none;
   padding: 0;
+  background: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: inherit;
 }
 
 .resources {

--- a/src/StatusBar.css
+++ b/src/StatusBar.css
@@ -3,10 +3,15 @@
   gap: 10px;
   margin-bottom: 10px;
   font-size: 14px;
+  background: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: inherit;
 }
 
 .status-bar span {
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.1);
   padding: 2px 6px;
   border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- refine board tiles with rounded corners
- style D-pad buttons and toggle
- polish inventory and status bar design

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd8b69dc832b93b01540f2eb8a74