### PR TITLE
Add use-item context update test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -83,3 +83,16 @@ test('status bar displays resource values', () => {
   expect(status).toHaveTextContent(/Gold:/i);
   expect(status).toHaveTextContent(/Turn:/i);
 });
+
+test('using inventory item updates context and status bar', () => {
+  render(<App />);
+  const status = screen.getByTestId('status-bar');
+  expect(status).toHaveTextContent('Gold: 0');
+
+  fireEvent.keyDown(document, { key: 'ArrowDown', code: 'ArrowDown' });
+
+  const useButton = screen.getByRole('button', { name: /use/i });
+  fireEvent.click(useButton);
+
+  expect(status).toHaveTextContent('Gold: 10');
+});

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -40,7 +40,7 @@ function Board() {
     new Monster(-1, -1),
   ]);
 
-  const { consumeTurn } = useContext(GameContext);
+  const { consumeTurn, setGold, setHealth } = useContext(GameContext);
   const [itemsOnMap, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
   const [resources, setResources] = useState({ hp: 100, gold: 0 });
@@ -140,15 +140,17 @@ function Board() {
       if (!item) return inv;
       if (item.type === 'gold') {
         setResources(res => ({ ...res, gold: res.gold + item.amount }));
+        if (setGold) setGold(g => g + item.amount);
       } else if (item.type === 'heal') {
         setResources(res => ({
           ...res,
           hp: Math.min(res.hp + item.amount, 100),
         }));
+        if (setHealth) setHealth(h => Math.min(h + item.amount, 100));
       }
       return inv.filter((_, i) => i !== index);
     });
-  }, []);
+  }, [setGold, setHealth]);
 
   const tiles = [];
   for (let r = 0; r < BOARD_SIZE; r++) {


### PR DESCRIPTION
## Summary
- update `Board` to sync GameContext when using an item
- test that using an item updates context and StatusBar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd8cf5e0832bbc5d44d722802278