### PR TITLE
Remove duplicate status from Board

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -184,7 +184,6 @@ function Board() {
 
   return (
     <div className={`board-container${showDpad ? '' : ' collapsed'}`}>
-      <div className="status" data-testid="status">HP: {health}</div>
       <div className="board" data-testid="board">
         {tiles}
       </div>

--- a/src/Monster.test.js
+++ b/src/Monster.test.js
@@ -17,15 +17,15 @@ test('monster appears on the board', () => {
 
 // 몬스터 위로 이동하면 체력이 감소한다
 test('colliding with monster decreases player HP', () => {
-  render(
+  const { container } = render(
     <GameProvider>
       <Board />
     </GameProvider>
   );
-  const status = screen.getByTestId('status');
-  expect(status).toHaveTextContent('HP: 100');
+  const resources = container.querySelector('.resources');
+  expect(resources).toHaveTextContent('HP: 100');
 
   fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
 
-  expect(status).toHaveTextContent('HP: 99');
+  expect(resources).toHaveTextContent('HP: 99');
 });


### PR DESCRIPTION
## Summary
- remove `status` element from Board to keep a single resource display
- adjust monster test to read HP from `.resources`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fff5080e4832b920e11b5327893c0