### PR TITLE
Add MapView overlay

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import './Board.css';
 import Inventory from './components/Inventory';
+import MapView from './components/MapView';
 import Monster from './entities/Monster';
 import { GameContext } from './GameContext';
 import level1 from './maps/level1';
@@ -30,6 +31,7 @@ const INITIAL_ITEMS = {
 function Board() {
   const stepAudioRef = useRef(null);
   const [showDpad, setShowDpad] = useState(true);
+  const [showMap, setShowMap] = useState(false);
   // 전역 맵에서의 좌표를 관리한다
   const [worldPosition, setWorldPosition] = useState({ row: 0, col: 0 });
   const [monsters, setMonsters] = useState([
@@ -197,8 +199,14 @@ function Board() {
           <button onClick={moveDown} aria-label="down">↓</button>
         </div>
       )}
+      <button type="button" onClick={() => setShowMap(true)}>
+        지도를 보기
+      </button>
       <div className="resources">HP: {health} Gold: {gold}</div>
       <Inventory items={inventory} onUse={useItem} />
+      {showMap && (
+        <MapView onClose={() => setShowMap(false)} worldPosition={worldPosition} monsters={monsters} />
+      )}
     </div>
   );
 }

--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -1,0 +1,42 @@
+.mapview-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.mapview {
+  background: #fff;
+  padding: 10px;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.map-grid {
+  display: grid;
+  grid-template-columns: repeat(10, 16px);
+  grid-template-rows: repeat(10, 16px);
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.map-tile {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+
+.map-tile.hero {
+  box-shadow: inset 0 0 0 2px #f44336;
+}
+
+.map-tile.monster {
+  background-color: #2196f3;
+}

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import level1 from '../maps/level1';
+import './MapView.css';
+
+const tileColors = {
+  floor: '#8bc34a',
+  wall: '#9e9e9e',
+  water: '#42a5f5',
+  special: '#ffd700',
+};
+
+function MapView({ onClose, worldPosition, monsters }) {
+  const tiles = [];
+  for (let r = 0; r < level1.length; r += 1) {
+    for (let c = 0; c < level1[r].length; c += 1) {
+      const isHero = r === worldPosition.row && c === worldPosition.col;
+      const isMonster = monsters.some((m) => m.row === r && m.col === c);
+      const tileType = level1[r][c] || 'floor';
+      tiles.push(
+        <div
+          key={`${r}-${c}`}
+          className={`map-tile${isHero ? ' hero' : isMonster ? ' monster' : ''}`}
+          style={{ backgroundColor: tileColors[tileType] || tileColors.floor }}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="mapview-overlay" role="dialog">
+      <div className="mapview">
+        <div className="map-grid">{tiles}</div>
+        <button type="button" onClick={onClose}>닫기</button>
+      </div>
+    </div>
+  );
+}
+
+export default MapView;


### PR DESCRIPTION
## Summary
- implement a mini-map overlay component
- allow Board to open the map view

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc03def8832bb043e850ac545f20