### PR TITLE
Add sliding MenuPanel component

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -82,6 +82,15 @@
   margin-top: 10px;
 }
 
+.menu-button {
+  margin-top: 10px;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: inherit;
+}
+
 @media (max-width: 600px) {
   .dpad-toggle {
     display: block;

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import './Board.css';
 import Inventory from './components/Inventory';
+import MenuPanel from './components/MenuPanel';
 import Monster from './entities/Monster';
 import { GameContext } from './GameContext';
 import level1 from './maps/level1';
@@ -46,6 +47,7 @@ function Board() {
   } = useContext(GameContext);
   const [itemsOnMap, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
+  const [showMenu, setShowMenu] = useState(false);
 
   const handleCombat = useCallback((playerPos, list) => list
     .map((m) => {
@@ -198,7 +200,21 @@ function Board() {
         </div>
       )}
       <div className="resources">HP: {health} Gold: {gold}</div>
+      <button
+        type="button"
+        className="menu-button"
+        onClick={() => setShowMenu(true)}
+      >
+        Menu
+      </button>
       <Inventory items={inventory} onUse={useItem} />
+      {showMenu && (
+        <MenuPanel
+          inventory={inventory}
+          onUseItem={useItem}
+          onClose={() => setShowMenu(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/MenuPanel.css
+++ b/src/MenuPanel.css
@@ -1,0 +1,63 @@
+.menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 1000;
+}
+
+.menu-panel {
+  background: #fff;
+  width: 80%;
+  max-width: 320px;
+  height: 100%;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-out;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.menu-panel.open {
+  transform: translateX(0);
+}
+
+.tab-buttons {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+}
+
+.tab-buttons button {
+  flex: 1;
+  padding: 8px;
+  background: transparent;
+  border: none;
+  font-family: inherit;
+}
+
+.tab-buttons button.active {
+  background: #eee;
+}
+
+.tab-content {
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.close-button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: transparent;
+  border: none;
+  font-size: 16px;
+}
+
+.map-placeholder {
+  text-align: center;
+  padding: 20px;
+  color: #777;
+}

--- a/src/components/MenuPanel.jsx
+++ b/src/components/MenuPanel.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import Inventory from './Inventory';
+import '../MenuPanel.css';
+
+function MenuPanel({ inventory = [], onUseItem, onClose }) {
+  const tabs = [
+    {
+      id: 'inventory',
+      label: 'Inventory',
+      content: <Inventory items={inventory} onUse={onUseItem} />,
+    },
+    {
+      id: 'map',
+      label: 'Map',
+      content: (
+        <div className="map-placeholder">Map coming soon...</div>
+      ),
+    },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0].id);
+
+  return (
+    <div className="menu-overlay" role="dialog" aria-label="menu panel">
+      <div className="menu-panel open">
+        <button
+          type="button"
+          className="close-button"
+          onClick={onClose}
+          aria-label="close menu"
+        >
+          ×
+        </button>
+        <div className="tab-buttons">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={activeTab === tab.id ? 'active' : ''}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="tab-content">
+          {tabs.find((t) => t.id === activeTab)?.content}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MenuPanel;


### PR DESCRIPTION
## Summary
- create `MenuPanel.jsx` and associated CSS for sliding modal
- show inventory/map tabs inside MenuPanel
- add menu button to `Board` that opens the panel
- style the menu button

## Testing
- `npm test -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc052d78832ba9e47990d808ea8f