### PR TITLE
Fix MapView import path and extend tile colors

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import level1 from '../maps/level1';
+import openWorld from '../maps/openWorld';
 import './MapView.css';
 
 const tileColors = {
@@ -7,15 +7,19 @@ const tileColors = {
   wall: '#9e9e9e',
   water: '#42a5f5',
   special: '#ffd700',
+  desert: '#e0c070',
+  ice: '#a0e0ff',
+  forest: '#228b22',
+  ocean: '#1e90ff',
 };
 
 function MapView({ onClose, worldPosition, monsters }) {
   const tiles = [];
-  for (let r = 0; r < level1.length; r += 1) {
-    for (let c = 0; c < level1[r].length; c += 1) {
+  for (let r = 0; r < openWorld.length; r += 1) {
+    for (let c = 0; c < openWorld[r].length; c += 1) {
       const isHero = r === worldPosition.row && c === worldPosition.col;
       const isMonster = monsters.some((m) => m.row === r && m.col === c);
-      const tileType = level1[r][c] || 'floor';
+      const tileType = openWorld[r][c] || 'floor';
       tiles.push(
         <div
           key={`${r}-${c}`}


### PR DESCRIPTION
## Summary
- update MapView import path to use openWorld
- extend tileColors with desert, ice, forest, and ocean

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c0f450a0832bb169fc48a6b3fe6e