### PR TITLE
Update map size and remove resource panel

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -77,9 +77,6 @@
   font-family: inherit;
 }
 
-.resources {
-  margin-top: 10px;
-}
 
 .menu-button {
   margin-top: 10px;

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -208,7 +208,6 @@ function Board() {
       <button type="button" onClick={() => setShowMap(true)}>
         지도를 보기
       </button>
-      <div className="resources">HP: {health} Gold: {gold}</div>
       <button
         type="button"
         className="menu-button"

--- a/src/Monster.test.js
+++ b/src/Monster.test.js
@@ -1,14 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import Board from './Board';
-import { GameProvider } from './GameContext';
+import App from './App';
 
 // 몬스터가 보드에 표시되는지 확인
 test('monster appears on the board', () => {
-  render(
-    <GameProvider>
-      <Board />
-    </GameProvider>
-  );
+  render(<App />);
   const monsterTiles = screen.getAllByRole('presentation').filter(tile =>
     tile.classList.contains('monster')
   );
@@ -16,16 +11,13 @@ test('monster appears on the board', () => {
 });
 
 // 몬스터 위로 이동하면 체력이 감소한다
+
 test('colliding with monster decreases player HP', () => {
-  const { container } = render(
-    <GameProvider>
-      <Board />
-    </GameProvider>
-  );
-  const resources = container.querySelector('.resources');
-  expect(resources).toHaveTextContent('HP: 100');
+  render(<App />);
+  const status = screen.getByTestId('status-bar');
+  expect(status).toHaveTextContent('HP: 100');
 
   fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
 
-  expect(resources).toHaveTextContent('HP: 99');
+  expect(status).toHaveTextContent('HP: 99');
 });

--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -20,8 +20,8 @@
 
 .map-grid {
   display: grid;
-  grid-template-columns: repeat(10, 16px);
-  grid-template-rows: repeat(10, 16px);
+  grid-template-columns: repeat(20, 16px);
+  grid-template-rows: repeat(20, 16px);
   gap: 2px;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- adjust MapView grid to show 20×20 tiles
- remove the temporary resource readout from `Board`
- update styles and tests accordingly

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c0ffc428832bb2eeefd4249159ca