### PR TITLE
Fix item effect rerender

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -144,7 +144,7 @@ function Board() {
         return copy;
       });
     }
-  }, [worldPosition, itemsOnMap]);
+  }, [worldPosition]);
 
   const useItem = useCallback((index) => {
     setInventory((inv) => {


### PR DESCRIPTION
## Summary
- prevent extra rerender when collecting items by removing `itemsOnMap` from the item-checking `useEffect`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c3225564832b8c283515cde7026d