### PR TITLE
Add jungle and grassland colors

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -11,6 +11,8 @@ const tileColors = {
   ice: '#a0e0ff',
   forest: '#228b22',
   ocean: '#1e90ff',
+  jungle: '#006400',
+  grassland: '#7cfc00',
 };
 
 function MapView({ onClose, worldPosition, monsters }) {


### PR DESCRIPTION
## Summary
- add jungle and grassland colors for map tiles

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c3251690832bbec07c1ff859c717