### PR TITLE
Fix board context destructuring

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -48,9 +48,7 @@ function Board() {
 
   const {
     consumeTurn,
-    health,
     setHealth,
-    gold,
     setGold,
   } = useContext(GameContext);
   const [itemsOnMap, setItemsOnMap] = useState(INITIAL_ITEMS);


### PR DESCRIPTION
## Summary
- clean up `Board` component's context usage

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c690600c832bb570ff471ad31bfe