### PR TITLE
Fix Board effect lint comment

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -131,8 +131,8 @@ function Board() {
   }, [moveUp, moveDown, moveLeft, moveRight]);
 
   // 이동 후 아이템 획득 여부 체크
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const key = `${worldPosition.row},${worldPosition.col}`;
     const found = itemsOnMap[key];
     if (found) {


### PR DESCRIPTION
## Summary
- move eslint-disable-next-line comment before useEffect in Board

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c9d962cc832bbe1f3ceb4d7b4f15