### PR TITLE
Load world asynchronously

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -11,7 +11,7 @@ import MenuPanel from './components/MenuPanel';
 import MapView from './components/MapView';
 import Monster from './entities/Monster';
 import { GameContext } from './GameContext';
-import openWorld from './maps/openWorld';
+import loadWorld from './maps/loadWorld';
 import stepSfx from './assets/sounds/step.mp3';
 
 const tileColors = {
@@ -37,6 +37,7 @@ const INITIAL_ITEMS = {
 
 function Board() {
   const stepAudioRef = useRef(null);
+  const [world, setWorld] = useState(null);
   const [showDpad, setShowDpad] = useState(true);
   const [showMap, setShowMap] = useState(false);
   // 전역 맵에서의 좌표를 관리한다
@@ -95,6 +96,10 @@ function Board() {
 
   useEffect(() => {
     stepAudioRef.current = new Audio(stepSfx);
+  }, []);
+
+  useEffect(() => {
+    loadWorld().then(setWorld);
   }, []);
 
 
@@ -157,6 +162,13 @@ function Board() {
     });
   }, [setGold, setHealth]);
 
+  if (!world) {
+    return <div>Loading...</div>;
+  }
+
+  const rows = world.length;
+  const cols = world[0].length;
+
   const tiles = [];
   for (let r = 0; r < BOARD_SIZE; r++) {
     for (let c = 0; c < BOARD_SIZE; c++) {
@@ -167,8 +179,7 @@ function Board() {
       const isMonster = monsters.some(
         (m) => m.row === worldRow && m.col === worldCol,
       );
-      const rowData = openWorld[worldRow];
-      const tileType = rowData && rowData[worldCol] ? rowData[worldCol] : 'floor';
+      const tileType = world[(worldRow + rows) % rows][(worldCol + cols) % cols];
       tiles.push(
         <div
           key={`${worldRow}-${worldCol}`}
@@ -224,7 +235,12 @@ function Board() {
         />
       )}
       {showMap && (
-        <MapView onClose={() => setShowMap(false)} worldPosition={worldPosition} monsters={monsters} />
+        <MapView
+          onClose={() => setShowMap(false)}
+          worldPosition={worldPosition}
+          monsters={monsters}
+          world={world}
+        />
       )}
     </div>
   );

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import openWorld from '../maps/openWorld';
 import './MapView.css';
 
 const tileColors = {
@@ -15,13 +14,17 @@ const tileColors = {
   grassland: '#7cfc00',
 };
 
-function MapView({ onClose, worldPosition, monsters }) {
+function MapView({ onClose, worldPosition, monsters, world }) {
+  if (!world) {
+    return <div>Loading...</div>;
+  }
+
   const tiles = [];
-  for (let r = 0; r < openWorld.length; r += 1) {
-    for (let c = 0; c < openWorld[r].length; c += 1) {
+  for (let r = 0; r < world.length; r += 1) {
+    for (let c = 0; c < world[r].length; c += 1) {
       const isHero = r === worldPosition.row && c === worldPosition.col;
       const isMonster = monsters.some((m) => m.row === r && m.col === c);
-      const tileType = openWorld[r][c] || 'floor';
+      const tileType = world[r][c] || 'floor';
       tiles.push(
         <div
           key={`${r}-${c}`}

--- a/src/maps/loadWorld.js
+++ b/src/maps/loadWorld.js
@@ -1,0 +1,5 @@
+import openWorld from './openWorld';
+
+export default function loadWorld() {
+  return Promise.resolve(openWorld);
+}


### PR DESCRIPTION
## Summary
- load world map asynchronously
- support fallback loading screen while map is loading
- render tiles using wrapping logic

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612f2eef90832ba355ba383f109086