### PR TITLE
Fix item pickup useEffect

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -142,16 +142,17 @@ function Board() {
   // 이동 후 아이템 획득 여부 체크
   useEffect(() => {
     const key = `${worldPosition.row},${worldPosition.col}`;
-    const found = itemsOnMap[key];
-    if (found) {
-      setInventory(inv => [...inv, found]);
-      setItemsOnMap(prev => {
+    setItemsOnMap(prev => {
+      const found = prev[key];
+      if (found) {
+        setInventory(inv => [...inv, found]);
         const copy = { ...prev };
         delete copy[key];
         return copy;
-      });
-    }
-  }, [worldPosition, itemsOnMap]);
+      }
+      return prev;
+    });
+  }, [worldPosition]);
 
   const useItem = useCallback((index) => {
     setInventory((inv) => {


### PR DESCRIPTION
## Summary
- track item pickup using only the world position
- manage item removal inside the effect

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686131451398832ba903ff3f4d8974bd