### PR TITLE
Fix MapView world reference

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -241,8 +241,8 @@ function Board() {
       {showMap && (
         <MapView
           onClose={() => setShowMap(false)}
-          world={openWorld}
-          dimensions={{ rows: openWorld.length, cols: openWorld[0].length }}
+          world={world}
+          dimensions={{ rows: world.length, cols: world[0].length }}
           worldPosition={worldPosition}
           monsters={monsters}
         />

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import openWorld from '../maps/level1';
 import './MapView.css';
 
 const tileColors = {
@@ -27,13 +26,6 @@ function MapView({ onClose, worldPosition, monsters, world, dimensions }) {
       const isMonster = monsters.some((m) => m.row === r && m.col === c);
       const rowData = world[r] || [];
       const tileType = rowData[c] || 'floor';
-
-  const tiles = [];
-  for (let r = 0; r < world.length; r += 1) {
-    for (let c = 0; c < world[r].length; c += 1) {
-      const isHero = r === worldPosition.row && c === worldPosition.col;
-      const isMonster = monsters.some((m) => m.row === r && m.col === c);
-      const tileType = world[r][c] || 'floor';
       tiles.push(
         <div
           key={`${r}-${c}`}


### PR DESCRIPTION
## Summary
- pass the loaded `world` state into `MapView`
- clean up `MapView` and remove unused import

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686131468fe8832bbd187e851f669ed5