### PR TITLE
Update loadWorld to fetch CSV

### DIFF
--- a/src/maps/loadWorld.js
+++ b/src/maps/loadWorld.js
@@ -1,5 +1,5 @@
-import openWorld from './openWorld';
-
-export default function loadWorld() {
-  return Promise.resolve(openWorld);
+export default async function loadWorld() {
+  const res = await fetch(process.env.PUBLIC_URL + '/maps/world.csv');
+  const text = await res.text();
+  return text.trim().split('\n').map(row => row.split(','));
 }


### PR DESCRIPTION
## Summary
- load world map from public CSV file
- remove unused `openWorld` import

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861313910f8832ba31f525cc97beee5