### PR TITLE
Fix ESLint unused variable warning

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -53,7 +53,7 @@ function Board() {
     setHealth,
     setGold,
   } = useContext(GameContext);
-  const [itemsOnMap, setItemsOnMap] = useState(INITIAL_ITEMS);
+  const [, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
   const [showMenu, setShowMenu] = useState(false);
 


### PR DESCRIPTION
## Summary
- address ESLint error by ignoring the `itemsOnMap` state value

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686134fbf0f4832ba81d6f6af4b608a9