### PR TITLE
Add sliding inventory panel

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -55,6 +55,7 @@ function Board() {
   } = useContext(GameContext);
   const [, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
+  const [showInventory, setShowInventory] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
 
   const handleCombat = useCallback((playerPos, list) => list
@@ -227,11 +228,20 @@ function Board() {
       <button
         type="button"
         className="menu-button"
+        onClick={() => setShowInventory(prev => !prev)}
+      >
+        Inventory
+      </button>
+      <button
+        type="button"
+        className="menu-button"
         onClick={() => setShowMenu(true)}
       >
         Menu
       </button>
-      <Inventory items={inventory} onUse={useItem} />
+      <div className={`inventory-container${showInventory ? ' open' : ''}`}>
+        <Inventory items={inventory} onUse={useItem} />
+      </div>
       {showMenu && (
         <MenuPanel
           inventory={inventory}

--- a/src/components/Inventory.css
+++ b/src/components/Inventory.css
@@ -18,3 +18,19 @@
   border-radius: 4px;
   font-family: inherit;
 }
+
+.inventory-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  transform: translateY(100%);
+  transition: transform 0.3s ease-out;
+  display: flex;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.inventory-container.open {
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- allow toggling inventory panel from Board
- animate inventory container to slide from bottom

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861369ab9f8832bb3a27fac4b815f5c