### PR TITLE
Fix map tile borders

### DIFF
--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -27,8 +27,8 @@
 .map-tile {
   width: 16px;
   height: 16px;
-  border: 1px solid #ccc;
-  border-radius: 2px;
+  border: none;
+  border-radius: 3px;
 }
 
 .map-tile.hero {


### PR DESCRIPTION
## Summary
- remove visible border around map tiles
- adjust corner radius for a board-piece look

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613b5f951c832bab7b7e06bc04cecd