### PR TITLE
Update menu drawer with map integration

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -6,9 +6,7 @@ import React, {
   useContext,
 } from 'react';
 import './Board.css';
-import Inventory from './components/Inventory';
 import MenuPanel from './components/MenuPanel';
-import MapView from './components/MapView';
 import Monster from './entities/Monster';
 import { GameContext } from './GameContext';
 import loadWorld from './maps/loadWorld';
@@ -40,7 +38,6 @@ function Board() {
   const stepAudioRef = useRef(null);
   const [world, setWorld] = useState(null);
   const [showDpad, setShowDpad] = useState(true);
-  const [showMap, setShowMap] = useState(false);
   // 전역 맵에서의 좌표를 관리한다
   const [worldPosition, setWorldPosition] = useState({ row: 0, col: 0 });
   const [monsters, setMonsters] = useState([
@@ -55,7 +52,6 @@ function Board() {
   } = useContext(GameContext);
   const [, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
-  const [showInventory, setShowInventory] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
 
   const handleCombat = useCallback((playerPos, list) => list
@@ -224,16 +220,6 @@ function Board() {
           <button className="down btn" onClick={moveDown} aria-label="down">↓</button>
         </div>
       )}
-      <button type="button" className="btn" onClick={() => setShowMap(true)}>
-        지도를 보기
-      </button>
-      <button
-        type="button"
-        className="menu-button btn"
-        onClick={() => setShowInventory(prev => !prev)}
-      >
-        Inventory
-      </button>
       <button
         type="button"
         className="menu-button btn"
@@ -241,23 +227,15 @@ function Board() {
       >
         Menu
       </button>
-      <div className={`inventory-container${showInventory ? ' open' : ''}`}>
-        <Inventory items={inventory} onUse={useItem} />
-      </div>
       {showMenu && (
         <MenuPanel
           inventory={inventory}
           onUseItem={useItem}
           onClose={() => setShowMenu(false)}
-        />
-      )}
-      {showMap && (
-        <MapView
-          onClose={() => setShowMap(false)}
           world={world}
-          dimensions={{ rows: world.length, cols: world[0].length }}
           worldPosition={worldPosition}
           monsters={monsters}
+          dimensions={{ rows: world.length, cols: world[0].length }}
         />
       )}
     </div>

--- a/src/MenuPanel.css
+++ b/src/MenuPanel.css
@@ -6,23 +6,24 @@
   bottom: 0;
   background: rgba(0, 0, 0, 0.4);
   display: flex;
-  justify-content: flex-end;
+  align-items: flex-end;
+  justify-content: center;
   z-index: 1000;
 }
 
 .menu-panel {
   background: #fff;
-  width: 80%;
-  max-width: 320px;
-  height: 100%;
-  transform: translateX(100%);
+  width: 100%;
+  height: 70%;
+  max-height: 70%;
+  transform: translateY(100%);
   transition: transform 0.3s ease-out;
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.3);
   position: relative;
 }
 
 .menu-panel.open {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 .tab-buttons {

--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -38,3 +38,9 @@
 .map-tile.monster {
   background-color: #2196f3;
 }
+
+.mapview-inline {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0;
+}

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -15,7 +15,14 @@ const tileColors = {
 };
 
 
-function MapView({ onClose, worldPosition, monsters, world, dimensions }) {
+function MapView({
+  onClose,
+  worldPosition,
+  monsters,
+  world,
+  dimensions,
+  inline = false,
+}) {
   const rows = dimensions?.rows ?? world.length;
   const cols = dimensions?.cols ?? (world[0] ? world[0].length : 0);
 
@@ -36,18 +43,26 @@ function MapView({ onClose, worldPosition, monsters, world, dimensions }) {
     }
   }
 
+  const grid = (
+    <div
+      className="map-grid"
+      style={{
+        gridTemplateColumns: `repeat(${cols}, 16px)`,
+        gridTemplateRows: `repeat(${rows}, 16px)`,
+      }}
+    >
+      {tiles}
+    </div>
+  );
+
+  if (inline) {
+    return <div className="mapview-inline">{grid}</div>;
+  }
+
   return (
     <div className="mapview-overlay" role="dialog">
       <div className="mapview">
-        <div
-          className="map-grid"
-          style={{
-            gridTemplateColumns: `repeat(${cols}, 16px)`,
-            gridTemplateRows: `repeat(${rows}, 16px)`,
-          }}
-        >
-          {tiles}
-        </div>
+        {grid}
         <button type="button" onClick={onClose}>닫기</button>
       </div>
     </div>

--- a/src/components/MenuPanel.jsx
+++ b/src/components/MenuPanel.jsx
@@ -1,8 +1,16 @@
 import React, { useState } from 'react';
 import Inventory from './Inventory';
+import MapView from './MapView';
 import '../MenuPanel.css';
 
-function MenuPanel({ inventory = [], onUseItem, onClose }) {
+function MenuPanel({
+  inventory = [],
+  onUseItem,
+  onClose,
+  world,
+  worldPosition,
+  monsters,
+}) {
   const tabs = [
     {
       id: 'inventory',
@@ -13,7 +21,13 @@ function MenuPanel({ inventory = [], onUseItem, onClose }) {
       id: 'map',
       label: 'Map',
       content: (
-        <div className="map-placeholder">Map coming soon...</div>
+        <MapView
+          inline
+          world={world}
+          worldPosition={worldPosition}
+          monsters={monsters}
+          dimensions={{ rows: world?.length || 0, cols: world && world[0] ? world[0].length : 0 }}
+        />
       ),
     },
   ];


### PR DESCRIPTION
## Summary
- show map in menu panel
- simplify board UI to only open the menu
- slide menu panel from bottom like a drawer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613b4f3fac832baa312fe38cc6b8eb