### PR TITLE
Fix column wrapping test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -102,12 +102,12 @@ test('column index wraps to 0 when moving right past the edge', async () => {
   const board = await screen.findByTestId('board');
   const centerIndex = Math.floor(board.children.length / 2);
 
-  for (let i = 0; i < 9; i += 1) {
+  for (let i = 0; i < 19; i += 1) {
     fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
   }
 
   let centerTile = screen.getByTestId('board').children[centerIndex];
-  expect(Number(centerTile.getAttribute('data-col'))).toBe(9);
+  expect(Number(centerTile.getAttribute('data-col'))).toBe(19);
 
   fireEvent.keyDown(document, { key: 'ArrowRight', code: 'ArrowRight' });
 


### PR DESCRIPTION
## Summary
- update the wraparound test in `App.test.js` to use 19 moves and verify index 19 before wrapping to 0

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620cdc42c4832ba0d882bc246aac7a