### PR TITLE
Add shared tile color mapping

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -11,20 +11,7 @@ import Monster from './entities/Monster';
 import { GameContext } from './GameContext';
 import loadWorld from './maps/loadWorld';
 import stepSfx from './assets/sounds/step.mp3';
-
-
-const tileColors = {
-  floor: '#8bc34a',  // 초원
-  wall: '#9e9e9e',   // 벽
-  water: '#42a5f5',  // 바다
-  special: '#ffd700', // 특별 지형
-  desert: '#e0c070',
-  ice: '#a0e0ff',
-  forest: '#228b22',
-  ocean: '#1e90ff',
-  jungle: '#006400',
-  grassland: '#7cfc00'
-};
+import tileColors from './utils/tileColors';
 
 const BOARD_SIZE = 7;
 const CENTER = Math.floor(BOARD_SIZE / 2);

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,18 +1,6 @@
 import React from 'react';
 import './MapView.css';
-
-const tileColors = {
-  floor: '#8bc34a',
-  wall: '#9e9e9e',
-  water: '#42a5f5',
-  special: '#ffd700',
-  desert: '#e0c070',
-  ice: '#a0e0ff',
-  forest: '#228b22',
-  ocean: '#1e90ff',
-  jungle: '#006400',
-  grassland: '#7cfc00',
-};
+import tileColors from '../utils/tileColors';
 
 
 function MapView({

--- a/src/utils/tileColors.js
+++ b/src/utils/tileColors.js
@@ -1,0 +1,14 @@
+const tileColors = {
+  floor: '#8bc34a', // 초원
+  wall: '#9e9e9e', // 벽
+  water: '#42a5f5', // 바다
+  special: '#ffd700', // 특별 지형
+  desert: '#e0c070',
+  ice: '#a0e0ff',
+  forest: '#228b22',
+  ocean: '#1e90ff',
+  jungle: '#006400',
+  grassland: '#7cfc00',
+};
+
+export default tileColors;


### PR DESCRIPTION
## Summary
- centralize tile color definitions in `src/utils/tileColors.js`
- reuse shared tile color map in `Board` and `MapView`

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620cde7814832b9995b5e07dd3b328