### PR TITLE
Show items on board

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -18,6 +18,7 @@
   background-color: #f8f8f8;
   border-radius: 8px;
   font-family: inherit;
+  position: relative;
 }
 
 .tile.hero {
@@ -26,6 +27,19 @@
 
 .tile.monster {
   background-color: #2196f3;
+}
+
+.tile.item::after {
+  content: '\1F381';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
 }
 
 .status {

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -50,7 +50,7 @@ function Board() {
     setHealth,
     setGold,
   } = useContext(GameContext);
-  const [, setItemsOnMap] = useState(INITIAL_ITEMS);
+  const [itemsOnMap, setItemsOnMap] = useState(INITIAL_ITEMS);
   const [inventory, setInventory] = useState([]);
   const [showMenu, setShowMenu] = useState(false);
 
@@ -184,11 +184,12 @@ function Board() {
       const isMonster = monsters.some(
         (m) => m.row === worldRow && m.col === worldCol,
       );
+      const hasItem = Boolean(itemsOnMap[`${worldRow},${worldCol}`]);
       const tileType = world[(worldRow + rows) % rows][(worldCol + cols) % cols];
       tiles.push(
         <div
           key={`${worldRow}-${worldCol}`}
-          className={`tile${isHero ? ' hero' : isMonster ? ' monster' : ''}`}
+          className={`tile${isHero ? ' hero' : isMonster ? ' monster' : ''}${hasItem ? ' item' : ''}`}
           role="presentation"
           data-row={worldRow}
           data-col={worldCol}


### PR DESCRIPTION
## Summary
- add item indicator styles
- track items on board and mark tiles with items

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620ce182c0832bb0e08a8eaec0a9d4