### PR TITLE
Use canvas for map rendering

### DIFF
--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -18,25 +18,10 @@
   text-align: center;
 }
 
-.map-grid {
-  display: grid;
-  gap: 2px;
+.map-canvas {
+  display: block;
   margin-bottom: 10px;
-}
-
-.map-tile {
-  width: 16px;
-  height: 16px;
-  border: none;
-  border-radius: 3px;
-}
-
-.map-tile.hero {
-  box-shadow: inset 0 0 0 2px #f44336;
-}
-
-.map-tile.monster {
-  background-color: #2196f3;
+  image-rendering: pixelated;
 }
 
 .mapview-inline {

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import './MapView.css';
 import tileColors from '../utils/tileColors';
 
@@ -13,35 +13,41 @@ function MapView({
 }) {
   const rows = dimensions?.rows ?? world.length;
   const cols = dimensions?.cols ?? (world[0] ? world[0].length : 0);
+  const tileSize = 16;
+  const canvasRef = useRef(null);
 
-  const tiles = [];
-  for (let r = 0; r < rows; r += 1) {
-    for (let c = 0; c < cols; c += 1) {
-      const isHero = r === worldPosition.row && c === worldPosition.col;
-      const isMonster = monsters.some((m) => m.row === r && m.col === c);
-      const rowData = world[r] || [];
-      const tileType = rowData[c] || 'floor';
-      tiles.push(
-        <div
-          key={`${r}-${c}`}
-          className={`map-tile${isHero ? ' hero' : isMonster ? ' monster' : ''}`}
-          style={{ backgroundColor: tileColors[tileType] || tileColors.floor }}
-        />
-      );
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = cols * tileSize;
+    canvas.height = rows * tileSize;
+
+    for (let r = 0; r < rows; r += 1) {
+      for (let c = 0; c < cols; c += 1) {
+        const rowData = world[r] || [];
+        const tileType = rowData[c] || 'floor';
+        ctx.fillStyle = tileColors[tileType] || tileColors.floor;
+        ctx.fillRect(c * tileSize, r * tileSize, tileSize, tileSize);
+      }
     }
-  }
 
-  const grid = (
-    <div
-      className="map-grid"
-      style={{
-        gridTemplateColumns: `repeat(${cols}, 16px)`,
-        gridTemplateRows: `repeat(${rows}, 16px)`,
-      }}
-    >
-      {tiles}
-    </div>
-  );
+    ctx.fillStyle = '#f44336';
+    ctx.fillRect(
+      worldPosition.col * tileSize + 4,
+      worldPosition.row * tileSize + 4,
+      tileSize - 8,
+      tileSize - 8,
+    );
+
+    ctx.fillStyle = '#2196f3';
+    monsters.forEach((m) => {
+      ctx.fillRect(m.col * tileSize + 4, m.row * tileSize + 4, tileSize - 8, tileSize - 8);
+    });
+  }, [world, worldPosition, monsters, rows, cols]);
+
+  const grid = <canvas ref={canvasRef} className="map-canvas" />;
 
   if (inline) {
     return <div className="mapview-inline">{grid}</div>;


### PR DESCRIPTION
## Summary
- speed up `MapView` by rendering the world to a `<canvas>`
- simplify map styles for canvas

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686211f1669c832bb92df5e0a3db8f7c