### PR TITLE
Update map tile scaling

### DIFF
--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -22,6 +22,8 @@
   display: block;
   margin-bottom: 10px;
   image-rendering: pixelated;
+  max-width: 200px;
+  max-height: 200px;
 }
 
 .mapview-inline {

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -13,7 +13,8 @@ function MapView({
 }) {
   const rows = dimensions?.rows ?? world.length;
   const cols = dimensions?.cols ?? (world[0] ? world[0].length : 0);
-  const tileSize = 16;
+  const maxSize = 200;
+  const tileSize = Math.min(maxSize / cols, maxSize / rows);
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -23,6 +24,8 @@ function MapView({
     if (!ctx) return;
     canvas.width = cols * tileSize;
     canvas.height = rows * tileSize;
+    canvas.style.width = `${maxSize}px`;
+    canvas.style.height = `${maxSize}px`;
 
     for (let r = 0; r < rows; r += 1) {
       for (let c = 0; c < cols; c += 1) {


### PR DESCRIPTION
## Summary
- size MapView canvas by calculating tile size so map fits within 200px box
- limit canvas element to 200px via CSS

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862175f3a7c832b917d6fc038fd6861